### PR TITLE
Cleaned up the preamble and a few other bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.aux
+*.log
+*.toc
+*.out
+gitt.pdf

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ html:
 
 clean:
 	rm gitt -Rf
+	rm -f *.aux *.log *.out *.toc gitt.pdf
 
 join:
 	pdfjoin images/source/fcover.pdf gitt.pdf --rotateoversize 'false' --outfile output.pdf
 
 final: pdf join
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: pdf html
 
 pdf:
 	pdflatex gitt.tex
+	pdflatex gitt.tex
+	pdflatex gitt.tex
 
 html:
 	latex2html -html 4.0,unicode,latin1,utf8 -split 2 gitt.tex 

--- a/afterhours2.tex
+++ b/afterhours2.tex
@@ -7,7 +7,7 @@ This After Hours section is going to get a little deep.  For some of you it may 
 
 To start with, we are going to use the Git repository that we have been playing with in Week 2 and take a deeper look at what is actually inside a Git repository.  Let us view the directory structure, to see what has been created in the \texttt{.git} folder.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo/.git$ ls -la
 total 52
 drwxr-xr-x  8 john john 4096 2011-03-31 20:35 .
@@ -68,7 +68,7 @@ So, when we commit into the repository we create a commit object.  The commit ob
 
 So now we know what a basic repository should look like, let us go through each stage of our committing in \textbf{Week 2} and see how it is built up at each stage.  Below is a consolidated list of all the objects in the repository.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 ./09/5b9cda52807c9c11781ec0a4aee927787b61f1
 ./16/3f06147a449e724d0cfd484c3334709e8e1fce
 ./34/a5dff148e70c12310cda0800d6bcaf82530bdc
@@ -82,19 +82,19 @@ So now we know what a basic repository should look like, let us go through each 
 
 In order to start rebuilding a picture of our repository, let us first find out what the first commit to our repository was.  Looking back in \emph{Week 2} we can see the following trimmed output.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 [master (root-commit) cfe23cb] My First Ever Commit
 \end{Verbatim}
 
 So we need to start with the object that begins \texttt{cfe23cb}.  Remember in the description above about the SHA-1 hashes, the first two bytes are the directory name.  We are looking for a file that starts with the characters \texttt{e23cb} and it will be in the directory called \texttt{cf}.  By George!  Looking at the list above, we can see that there is one file which fits the bill.  In fact it would be a little ambiguous if there were two.  It \emph{could} happen that we would have two SHA-1 hashes  that started with the same seven characters, but it's not likely.  The line we are interested in is listed below.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 ./cf/e23cbe0150fda69a004e301828097935ec4397}
 \end{Verbatim}
 
 It would be nice if we could find out a little more about this object, and confirm that it is what we expect it to be.  to start with, let us run the linux \texttt{file} command on it, to see what it makes of it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~/coderepo/.git/objects/cf$ file 
  e23cbe0150fda69a004e301828097935ec4397 
 e23cbe0150fda69a004e301828097935ec4397: VAX COFF executable - 
@@ -117,7 +117,7 @@ Commands which get a little down and dirty with the details are called Plumbing 
 
 If we run this plumbing command against our object, and supply the \texttt{-t} parameter, \texttt{git cat-file} will tell us the type of the object.  If we run it with the \texttt{-s} parameter, it will tell us the size.  Finally, running it with the \texttt{-p} parameter we can see what the object actually contains.  Each of these has been demonstrated below.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -t cfe23c
 commit
 john@satsuki:~/coderepo$ git cat-file -s cfe23c
@@ -134,7 +134,7 @@ john@satsuki:~/coderepo$
 
 Fantastic!  We now have a way of confirming the objects are what we think they are.  If we were to run the command against every file in the repository, we would end up with a list that would look something like the one below.  Notice our commit object sat in the middle.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 ./09/5b9cda52807c9c11781ec0a4aee927787b61f1     blob
 ./16/3f06147a449e724d0cfd484c3334709e8e1fce     commit
 ./34/a5dff148e70c12310cda0800d6bcaf82530bdc     tree
@@ -148,7 +148,7 @@ Fantastic!  We now have a way of confirming the objects are what we think they a
 
 Now things start to get interesting.  Did you also notice the tree SHA-1 hash mentioned when we ran \texttt{git cat-file -p}?  This is the tree object that stores the file structure.  Why don't we run the command against that file too?
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -p 34a5dff
 100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391	
  my_first_committed_file
@@ -157,7 +157,7 @@ john@satsuki:~/coderepo$
 
 We can now see a list of all files that were present in that snapshot of the working tree.  In our case this just happens to be one file.  Using our command one last time against the object name of the file, we can see the actual contents of the file.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -p e69de29
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
@@ -172,7 +172,7 @@ At first glance one may consider it odd that there is nothing in there.  However
 
 If we pick another commit object from the list and run our command on it we can see something new has appeared in the output.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -p 163f061
 tree 3ffa7ab6dafef2bc38a70a39c53604c333ed4d7a
 parent cfe23cbe0150fda69a004e301828097935ec4397

--- a/afterhours2.tex
+++ b/afterhours2.tex
@@ -107,23 +107,13 @@ The \texttt{file} command, tells us that the file is actually of \texttt{VAX COF
 \subsection{Out comes the wrench}
 Wouldn't it be nice if we could view the data that was inside the file simply, without having to write out own tools.  If you look through the Git man page, you will find one listed under the \textbf{Interrogation} section, called \texttt{git cat-file}.  Anyone who has spent any time with Git will know what the \texttt{cat} command does.  \texttt{cat} is used to display the contents of files.  In Git, this command is used to display the contents, type or size of a repository object, be it either of type commit, tree or blob.
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Information}{What's with all the wrenches?}
 You may have noticed the less than subtle references to plumbing.  Git has two types of commands.  Those that are readily available to the end user, and those that are not.  
 
 The commands that are readily available to the end user are called Porcelain commands because they have been refined and are simple to use, think Tap and Sink.  
 
 Commands which get a little down and dirty with the details are called Plumbing commands because they are dealing with the primitive objects that make things work, think Pipes and Joints.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {What's with all the wrenches?};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Information}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 If we run this plumbing command against our object, and supply the \texttt{-t} parameter, \texttt{git cat-file} will tell us the type of the object.  If we run it with the \texttt{-s} parameter, it will tell us the size.  Finally, running it with the \texttt{-p} parameter we can see what the object actually contains.  Each of these has been demonstrated below.
 
@@ -204,16 +194,7 @@ This commit object has an extra field.  This field is the \texttt{parent} field.
 
 Hopefully you can see from this diagram that Git will reuse objects as discussed above.  This diagram describes the repository layout completely and if you correlate, we have correctly identified and accounted for each object in the repository.  Now we know how to traverse a repository.  In \emph{Week 3} we find the Git commands to let us do that without having to break out the wrenches and resort to plumbing.  After all, why use a wrench to turn on a tap?
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Note}{Packing for a holiday?}
 It is worth noting that the objects noted above are not the only objects that you will find in the \texttt{objects} folder.  Git will sometimes clean itself up and perform packing operations.  This is out of scope for this chapter though.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Packing for a holiday?};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Note}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
+

--- a/afterhours3.tex
+++ b/afterhours3.tex
@@ -10,12 +10,12 @@ In essence the task of calculating a diff is that of finding the differences bet
 Though we are not going to go into the problem in great detail, it is useful to know what actually happens at this level.  Essentially you have two sequences, for now we are going to simplify the problem and work on a string of letters.
 
 Old string: 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 a b c d e j k l m p r s
 \end{Verbatim}
 
 New string: 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 a c d f g h i j n o p t u
 \end{Verbatim}
 
@@ -23,14 +23,14 @@ The challenge is to find the longest sequence of items that is present in both o
 
 In our example case, this is as follows
 LCS string: 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 a c d j p
 \end{Verbatim}
 
 Comparing this to each of our strings above, it is easy to generate a diff.  If the items are present in the \emph{Old string}, but not in the LCS string then they must have been deleted.  Conversely if they are present in the \emph{New string}, but not the LCS, then they must have been additions.  Putting this into practice in our example and marking deletions with \texttt{-} and additions with \texttt{+}, we get the following:
 
 Diff string:
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 b e fghi klm o rs tu
 - - ++++ --- + -- ++
 \end{Verbatim}
@@ -42,7 +42,7 @@ Tags can actually do a little more than just hold a single identifier to a speci
 
 Firstly we can use the \texttt{git tag} command to show all tags that are currently in the repository.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git tag
 v0.9
 v1.0a
@@ -51,14 +51,14 @@ john@satsuki:~/coderepo$
 
 Now let us create a new tag and give it some extra information.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git tag v1.0b -m 'This is an annotated tag'
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
 
 Unfortunately Git was not particularly forthcoming with information on the creation of the tag.  On saying that, it is not difficult for us to use the \texttt{git show} command to see what we have done.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git show v1.0b
 tag v1.0b
 Tagger: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -98,7 +98,7 @@ Now that we have learnt a little about how to play with tags, we should probably
 
 The implementation of tags in Git is very simple indeed.  We are going to jump into the \texttt{.git} directory and take a look at a simple output from some commands.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ cd .git/
 john@satsuki:~/coderepo/.git$ ls
 branches        config       HEAD   index  logs     refs
@@ -113,7 +113,7 @@ john@satsuki:~/coderepo/.git/refs/tags$
 
 Inside the \texttt{.git/refs/tags} folder, there is a file for every single tag in the system.  This file contains a single string of characters.  That string looks oddly like an SHA-1 commit to me.  Using the tricks that we learnt in the last After Hours section, we can interrogate the Git repository, by throwing a few wrenches at it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -p a022d4
 tree 96551f45496232c0ec6b389731d55fa3d7e1c8fd
 parent 9938a0c30940dccaeddce4bb2eb151fba3a21ae5
@@ -129,7 +129,7 @@ john@satsuki:~/coderepo$
 
 Excellent!  Just as we expected.  So Git stores the SHA-1 hash for the commit we are referring to, in a file which has the same name as the tag.  Just for clarity, let us run the same set of commands against our newly created annotated tag.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ cd .git/refs/tags/
 john@satsuki:~/coderepo/.git/refs/tags$ cat v1.0b
 6cbcf47957589bf4b84cc934a26731636d021574
@@ -138,7 +138,7 @@ john@satsuki:~/coderepo/.git/refs/tags$
 
 Hang on a minute!  Shouldn't the output of the \texttt{v1.0a} and \texttt{v1.0b} files be the same.  There were both created at the same point in the repositories history.  They were both supposed to be pointing to the same commit.  Let us use a little plumbing and see what is going on.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -t 6cbcf4
 tag
 john@satsuki:~/coderepo$ 
@@ -148,7 +148,7 @@ Interesting.  So it seems as if there is another type of object that can be adde
 
 When the tag was merely a pointer to a commit object, the repository required nothing more that the object that it was referring to, to be stored in the file.  Now we have more information, Git treats the information just as it would any other, by creating an object.  We can investigate this further and use the \texttt{-p} parameter to the \texttt{git cat-file} command to see exactly what is stored within this file.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git cat-file -p 6cbcf4
 object a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
 type commit

--- a/afterhours4.tex
+++ b/afterhours4.tex
@@ -37,7 +37,7 @@ As you can see from the second example, branch \textbf{B} was created from a com
 
 Let us go back to our example above.  We are attempting to merge in \textbf{zaney} to the \textbf{wonderful} branch.  We need to find the \textbf{C} in our equation.  To do this we could pour over Figure 1.  This should yield the result to be commit \textbf{9710177}.  Is there are way we can ask Git to do the same thing?  The following output introduces a new command that is used to find the \emph{Best Common Ancestor} for a given merge proposal.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-af4$ git merge-base wonderful zaney
 9710177657ae00665ca8f8027b17314346a5b1c4
 john@satsuki:~/coderepo-af4$ git cat-file -p 9710177

--- a/afterhours5.tex
+++ b/afterhours5.tex
@@ -11,7 +11,7 @@ To demonstrate this we are going to create a new branch called \textbf{fantasy} 
 
 So let us start by creating our branch and making some changes as shown below.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout -b fantasy
 Switched to a new branch 'fantasy'
 john@satsuki:~/coderepo$ echo "This is line 1" > newfile1 
@@ -24,7 +24,7 @@ john@satsuki:~/coderepo$ echo "This is another new line" >> newfile2
 
 Let us now just run a \texttt{git diff} to see exactly what the changes are.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff
 diff --git a/newfile1 b/newfile1
 index 44640b2..0eccf1a 100644
@@ -51,7 +51,7 @@ john@satsuki:~/coderepo$
 
 Now, we could just do \texttt{git commit -a} and be done with it, but what if we really wanted to split this information up into four commits?  We will introduce a new parameter to our \texttt{git add} tool from before.  We are going to use the \texttt{git add -p} or \texttt{git add --patch}.  This will allow us to interactively edit the hunks before they are committed.  To begin with, let us run \texttt{git add -p} and see what it is we need to do.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git add -p
 diff --git a/newfile1 b/newfile1
 index 44640b2..0eccf1a 100644
@@ -69,7 +69,7 @@ Stage this hunk [y,n,q,a,d,/,e,?]?
 
 We are given the options of \texttt{y,n,q,a,d,/,e,?}.  At first glance, this may seem rather daunting.  Let us choose the \texttt{?} and see what help is presented to us.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 Stage this hunk [y,n,q,a,d,/,e,?]? ?   
 y - stage this hunk
 n - do not stage this hunk
@@ -110,7 +110,7 @@ In fact, though the help mentioned a \textbf{split} command, we do not have this
 
 Here we are left in our chosen text editor, to either add, modify or remove lines from the hunk.  In our case, we are going to delete a few lines.  We only want to leave the first line of additions.  Just because we delete the others does not mean they are deleted from the working copy.  Remember, we are not editing the actual files here.  Just the hunks that are going to be staged.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 # Manual hunk edit mode -- see bottom for a quick guide
 @@ -1,2 +1,4 @@
 -A new file
@@ -132,7 +132,7 @@ Here we are left in our chosen text editor, to either add, modify or remove line
 
 After the deletes, the editors file should look like this.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 # Manual hunk edit mode -- see bottom for a quick guide
 @@ -1,2 +1,4 @@
 -A new file
@@ -151,7 +151,7 @@ After the deletes, the editors file should look like this.
 
 Once we quit our editor, we are then asked about the next hunk.  In our case, we are going to apply all of the changes to our second file during this commit.  To do this we are going to use the \texttt{a} option.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 diff --git a/newfile2 b/newfile2
 index 3545c1d..40efcce 100644
 --- a/newfile2
@@ -168,7 +168,7 @@ john@satsuki:~/coderepo$
 
 At first glance, we do not appear to have been left with any indication that anything has taken place.  In order to perform a check we shall run out obligatory \texttt{git diff}, both between the working copy and the index, and between the index and the last commit.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff
 diff --git a/newfile1 b/newfile1
 index f702b65..0eccf1a 100644
@@ -184,7 +184,7 @@ john@satsuki:~/coderepo$
 
 So above, we can see that the difference between the working copy and the index, or staging area, is the last three lines that we are not ready to commit yet.  Below we can see the difference between the staging area and the last commit to the repository.  This includes the three lines that we included during our interactive commit preparation.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff --cached
 diff --git a/newfile1 b/newfile1
 index 44640b2..f702b65 100644
@@ -208,7 +208,7 @@ john@satsuki:~/coderepo$
 
 We can now commit in the normal way, and continue to edit the working copy to stage the sections we require.  The following output is shortened for brevity.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git commit -m 'Added first line'
 [fantasy 03bd20c] Added first line
  2 files changed, 3 insertions(+), 2 deletions(-)
@@ -235,7 +235,7 @@ john@satsuki:~/coderepo$ git add -p
 
 We have gone through the process of editing each hunk for each commit and have performed the commits.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log
 commit a59e73b1dc571318a1154aa4c2fc591ab6f1f395
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -264,7 +264,7 @@ Date:   Wed Apr 13 23:55:32 2011 +0100
 
 Next we are going to see how to perform exactly the same procedure using \texttt{git gui}.  For a start, we are going to reset our branch HEAD and our index back to their state before we made the last four commits, however we are going to leave the working copy files in the state they were after these last four commits.  This is called a \textbf{mixed} reset, as it modifies the staging area and the HEAD, but does not touch the working files.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log --oneline
 a59e73b Added fourth line
 3ca3d62 Added third line
@@ -283,7 +283,7 @@ john@satsuki:~/coderepo$
 
 Now we will run a diff, just to be sure.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff
 diff --git a/newfile1 b/newfile1
 index 44640b2..0eccf1a 100644
@@ -338,7 +338,7 @@ Figure 3, shows what our file looks like after the first commit.  Interestingly,
 
 Let us now move back to our \textbf{master} branch and remove the \textbf{fantasy} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout master
 Switched to branch 'master'
 john@satsuki:~/coderepo$ git branch -D fantasy

--- a/chap1.tex
+++ b/chap1.tex
@@ -116,19 +116,9 @@ Once the Lieutenants are happy with their code, they make it available to the Di
 	\caption{Dictator and Lieutenant Workflow}
 \end{figure}
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Terminology}{Blessed}
 A blessed, or canonical, repository is one which has the approval of the managers of the project.  The blessed repository is supposed to be the de facto standard where all other clones are made from.  If there is one place where code should be correct, it is the blessed repository.  If you are hosting the project in a public place, the blessed repository will usually be the one that is made available to people as a stable point for developing from.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Blessed};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Terminology}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 The main thing to remember, is that Git can utilise any of these workflows.  This makes it a very flexible system, allowing you to work in whichever way you decide.
 

--- a/chap1.tex
+++ b/chap1.tex
@@ -12,7 +12,7 @@ John sat at his desk and looked out of the window.  The rain was drizzling down 
 
 Things didn't look good. 
  
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``So, what we'd like to know John, is just how a bug that was supposed to have been\ldots'' the CEO back-tracked, ``that was demonstrated as being fixed two weeks ago, made it into the final release of the software?''
 
@@ -24,7 +24,7 @@ Things didn't look good.
 
 The room fell silent and a few minutes of silence passed before the meeting was drawn to a close and John and his team were allowed to leave.
 
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``So, you're telling me that when Simon came back from holiday, he picked up an older copy of the library from the network share and pushed his latest code into that?''  Markus was holding back the anger.
 

--- a/chap2.tex
+++ b/chap2.tex
@@ -306,12 +306,7 @@ We have discarded the file which was residing in the index.  This is very import
 Everyone nodded in agreement.
 \end{trenches}
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Knowledge}{How do we change the commit message editor?}
 We spoke earlier about the configuration file and how it stores information about our Git instance.  Git can use any text editor you require, even a graphical one, though the need rarely arises.  As mentioned earlier, Git has a preference lever when talking about configuration.  First and foremost it will look in the repositories own 'config' file in the .git folder.  Then, it will look in the users \texttt{\textasciitilde/.gitconfig} file.  Finally, Git will look in your distributions own global folder.  
 
 If we wanted to change the editor that Git would use to modify commit messages, we can either modify the files directly, or run a command similar to the following;
@@ -327,13 +322,7 @@ git config --global core.editor "nano"
 \end{Verbatim}
 
 It is worth noting that you can also use the \$EDITOR environment variable to accomplish the same thing.  Many people use this in preference to the modifying the Git configuration simply because many other programs honour this setting.
-
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {How do we change the commit message editor?};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Knowledge}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 Now we know how to add files into the repository.  The question is, what do we do if we need to remove a file, or even rename it.  Well, git has some commands to help with that.  \texttt{git rm} and \texttt{git mv} delete and move files respectively.  Usually when you want to remove files from the repository, or move them, this is how you will handle it, but what if you have already deleted a tracked file manually?  Well, you have two options.  You could run \texttt{git commit -a}, but remember this will commit all changes to tracked files.  You could also run a \texttt{git rm <filename>} with the name of the file you have just deleted.  Git will then push that change into the staging area ready for commit.  The same applies to moving a file
 

--- a/chap2.tex
+++ b/chap2.tex
@@ -57,7 +57,7 @@ The first thing we need to do is to understand two very important things:
 
 The first of these is relatively easy to perform.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]
+\begin{Verbatim}
 john@satsuki:~$ mkdir coderepo
 john@satsuki:~$ cd coderepo/
 john@satsuki:~/coderepo$ git init
@@ -82,7 +82,7 @@ The commit object is also referred to by an SHA-1 hash.  This is different to ma
 
 The most simple way of committing a file into the repository is to create it, or bring it into your working copy and use the commands below.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ touch my_first_committed_file
 john@satsuki:~/coderepo$ git add my_first_committed_file
 john@satsuki:~/coderepo$ git commit -m 'My First Ever Commit'
@@ -94,7 +94,7 @@ john@satsuki:~/coderepo$
 
 What we have done here, is to create a new blank file and add it into the repository using Git's add command.  Then we have committed it into the repository.  Let's make a few changes to our working copy and see what the result is.  First we are going to add another two new files, then we are going to make changes to our original file and finally we are going to run git status to see what Git has to say about our changes.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ echo "Change1" > my_first_committed_file
 john@satsuki:~/coderepo$ touch my_second_committed_file
 john@satsuki:~/coderepo$ touch my_third_committed_file
@@ -120,7 +120,7 @@ john@satsuki:~/coderepo$
 
 So we can see that Git is reporting that there are changes to our first committed file, and that our second and third files are \textbf{untracked}.  Untracked files are ones which Git detects as being present in the working directory, but which haven't yet been added and there for upon running a commit, these files will not be added to the repository.  Notice that if we tried to run a commit now, nothing would actually be committed to the repository.  Even though there are changes to to my\_first\_committed\_file, we have not asked Git to include these.  So, let's go ahead and do that, and at the same time we'll make a few changes to my\_second\_committed\_file, and add those too.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git add my_first_committed_file
 john@satsuki:~/coderepo$ echo "Change1" > my_second_committed_file 
 john@satsuki:~/coderepo$ git add my_second_committed_file
@@ -156,7 +156,7 @@ John pointed at the screen.  ``Run a git status Klaus and I'll show you what the
 
 To understand what Klaus was getting in a spin about, let's make a change to my\_second\_committed\_file now and see how this affects things.  Remember we have already added the file, but we haven't yet made a commit.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ echo "Change2" >> 
  my_second_committed_file 
 john@satsuki:~/coderepo$ git status
@@ -187,7 +187,7 @@ How interesting!  We now have three sections and one of our files appears twice 
 
 So, if we go ahead and run our commit now, we will only have the changes marked in Changes to be committed appearing in our repository.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git commit -m 'Made a few changes to 
 first and second files'
 [master 163f061] Made a few changes to first and second files
@@ -200,7 +200,7 @@ In our examples, we have used the syntax \texttt{git commit -m 'Message'}.  This
 
 Let us finish off our round of committing by using the \texttt{git commit -a} option.  This commits all of the changes to files which are already tracked.  Consequently we do not have to specify the files with \texttt{git add}, like we have had to previously.  Any file which has been modified and has previously been added to the repository, will have it's changes committed upon running that command.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git status
 # On branch master
 # Changed but not updated:
@@ -220,7 +220,7 @@ no changes added to commit (use "git add" and/or "git commit
 john@satsuki:~/coderepo$ 
 \end{Verbatim} 
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git commit -a -m 'Finished adding 
  initial files'
 [master 9938a0c] Finished adding initial files
@@ -228,7 +228,7 @@ john@satsuki:~/coderepo$ git commit -a -m 'Finished adding
 john@satsuki:~/coderepo$ 
 \end{Verbatim} 
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git status
 # On branch master
 # Untracked files:
@@ -266,7 +266,7 @@ Mike chuckled, ``Sorry for interrupting dude.''
 
 The git reset is great at removing things from the index that you don't want to be there.  Of course, it can do a great many other things, but for now, let us concern ourselves with the scenario presented above.  We are working away, and have added a number of files into the index ready for committing, when we discover that we are actually not ready to commit them.  In the following example, we are going to add the file my\_third\_committed\_file and then remove it from the index.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git add my_third_committed_file
 john@satsuki:~/coderepo$ git status
 # On branch master
@@ -280,7 +280,7 @@ john@satsuki:~/coderepo$
 
 Notice how my\_third\_committed\_file is now ready to be committed to repository.  The problem is we need to add something more to it before we do.  Remember that when we run the git add command, we are copying the file from our working copy to the index.  If we decide we no longer want that file in the repository, we can run the following.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git reset my_third_committed_file
 john@satsuki:~/coderepo$ git status
 # On branch master
@@ -311,13 +311,13 @@ We spoke earlier about the configuration file and how it stores information abou
 
 If we wanted to change the editor that Git would use to modify commit messages, we can either modify the files directly, or run a command similar to the following;
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 git config core.editor "nano"
 \end{Verbatim}
 
 If we want the changes to apply globally, meaning it would affect all repositories we administrate as this user, unless overridden by a repository setting, we would run the following;
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 git config --global core.editor "nano"
 \end{Verbatim}
 

--- a/chap3.tex
+++ b/chap3.tex
@@ -72,26 +72,11 @@ The \texttt{git log} command shows us a chronological list of all of the commits
 \item \textbf{Commit Message} - This is the log message that was added along with the commit when it was created.  Hopefully you can now see how important it is to create useful and meaningful messages in here.
 \end{itemize}
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Note}{Note on Commit IDs}
 Please note, that if you are following the commits and changes on your local computer, you may not and probably will not have the same commit IDs as are presented in this book.  You are advised to use them here to follow what is happening, but to substitute them with your own values, when you start working with the rest of this chapter.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Note on Commit IDs};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Note}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Note}{Changing your identity}
 Particularly when working with other people, or when publishing your repository to a public location, it's a good idea to make sure people know who you are and how to get in contact with you.  Every time you make a commit to a repository, Git gives the opportunity to take note of who posted the commit.  When you first install Git, it probably won't have the correct information in there for you, so it's important that you take the time to set this up.
 
 To set up your name and email address, we need to modify the \texttt{gitconfig} again.  
@@ -103,12 +88,7 @@ $ git config --global user.email
 \end{Verbatim}
 
 That's it.  Now by default, Git will use this setting whenever you commit to a repository, unless you override it by locally modifying the repository's \texttt{.gitconfig}.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Changing your identity};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Note}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 \section{Day 2 - ``But I need more information''}
 \subsection{Digging a little deeper}
@@ -418,19 +398,9 @@ Notice that instead of using the dynamic reference HEAD, we have now used the ta
 
 You can find out more about tags and how to specify more information in the \emph{After Hours} section at the end of this Week.
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Note}{A little about tags}
 Tags are great and you should most definitely use them in your repositories to make good reference points, but there is one point that you should always remember.  Though we have not yet delved into the realms of remote branches, it is important to note that once you have tagged a certain commit, and pushed that to the repository, you cannot then remove that tag if someone else clones, or pulls your tags from that remote branch.  This will all become clearer during the next week, but fits in with the overall ethos of working with version control systems, if someone has seen the past, you should not EVER change it.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {A little about tags};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Note}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 \section{Day 5 - ``Putting things back the way they were''}
 \subsection{Revert, I say.  Revert!}

--- a/chap3.tex
+++ b/chap3.tex
@@ -10,7 +10,7 @@ Perhaps the best feature of a version control system is the level of accountabil
 
 By its very nature, a version control system is also a logging system.  Every time we committed something into the repository in the last chapter, we supplied a log message.  In fact, if we don't supply a commit message, let us see what happens.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git status
 # On branch master
 # Untracked files:
@@ -40,7 +40,7 @@ Rob placed his thumb and forefinger onto his chin.  ``Well, for now, I just want
 
 At its simplest, \texttt{git log} will give an output of all of the commits that have been applied to the current branch.  Depending on what type of machine you are using it on, the output from \texttt{git log} will be navigable, usually using the up and down arrows, with 'q' used to quit.  Let's have a quick look at the output of our test repository and see what the log messages look like.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log
 commit 9938a0c30940dccaeddce4bb2eb151fba3a21ae5
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -81,7 +81,7 @@ Particularly when working with other people, or when publishing your repository 
 
 To set up your name and email address, we need to modify the \texttt{gitconfig} again.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 $ git config --global user.name "John Haskins"
 $ git config --global user.email 
 "john.haskins@tamagoyakiinc.koala"
@@ -113,7 +113,7 @@ Git can actually do some rather powerful searching to assist a developer in thei
 
 In these instances, the \texttt{git log -S<string>} command comes to our aid.  This command will search through the commits in a repository and will return a list of commits which introduced or removed a specific string into the repository.  First of all, let's run this against our test repository.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log -SChange1
 commit 163f06147a449e724d0cfd484c3334709e8e1fce
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -125,7 +125,7 @@ john@satsuki:~/coderepo$
 
 You can see that \texttt{git log} has shown us the commit that instantiated the change.  As you can imagine, when using a large code base, this tool can be invaluable.  It allows us to pinpoint a specific moment when a certain string of text entered the repository.  When running this against a very large repository, this could take a long time, and so the ability to shrink the search scope down will result in a much faster result.  To do this we can append a path to our previous command.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log -SChange2 my_first_committed_file
 john@satsuki:~/coderepo$ git log -SChange2 my_second_committed_file
 commit 9938a0c30940dccaeddce4bb2eb151fba3a21ae5
@@ -147,7 +147,7 @@ The \texttt{git diff} command can show us exactly that.  For more information ab
 
 If we want to find out what the changes are between our current commit and one of the previous ones, we can write a command like the one below.  Notice that below, \textbf{163f06} refers to the second commit that we made to the repository.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff 163f06
 diff --git a/my_second_committed_file b/my_second_committed_file
 index 3ad4cc3..095b9cd 100644
@@ -161,7 +161,7 @@ john@satsuki:~/coderepo$
 
 What this is telling us, is that between \textbf{e86dd} and our current commit \textbf{6ca16}, we added the line \emph{Change2} to the file \texttt{my\_second\_committed\_file}.  We can see this by the preceding \texttt{+} on the line \texttt{Change2}.  Let's make a few changes to our repository and see how the diffs look.  We're actually going to make a few changes to the files using a text editor so that you can't see what we've done.  Then, hopefully, when we run the \texttt{git diff} you'll be able to see clearly what has happened.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log HEAD~1..HEAD
 commit a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -175,7 +175,7 @@ The command \texttt{git log HEAD\textasciitilde1..HEAD} tells Git to show us the
 
 As it turns out, John Haskins didn't really create a very meaningful log message.  \emph{Messed with a few files} is pretty unhelpful in the grand scheme of things.  So let's be thankful that this isn't Tamagoyaki Inc's core repository and take a look at what actually happened in the commit \textbf{a022d4}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff HEAD~1..HEAD
 diff --git a/my_second_committed_file b/my_second_committed_file
 index 095b9cd..c9887f8 100644
@@ -197,26 +197,26 @@ john@satsuki:~/coderepo$
 
 As you can see, we have several things going on here, so let's take each of them in isolation and see what is going on.  We are going to dissect the diff to see what each section means.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 diff --git a/my_second_committed_file b/my_second_committed_file
 \end{Verbatim}
 
 This first line tells us that we are dealing with \newline\texttt{my\_second\_committed\_file}.  This is showing that we are comparing the first revision, or a, against the second revision, b.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 index 095b9cd..c9887f8 100644
 \end{Verbatim}
 
 This second line actually tells us the beginning of the object IDs, as they are stored in the repository.  Note that these IDs are not the commit IDs, but the actual blob IDs that Git uses to refer to the file.  For more information on this, checkout the \emph{Object's living in harmony} breakout box.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 --- a/my_second_committed_file
 +++ b/my_second_committed_file
 \end{Verbatim}
 
 The next few lines are telling us which is the original file, and which is the new file, so we can use this as a reference.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 @@ -1,2 +1 @@
 -Change1
 -Change2
@@ -229,7 +229,7 @@ The three following lines show what actually took place.  Strings \texttt{Change
 
 Looking at the next diff segment, we can see it applies to a different file.  Essentially this hunk is no different to the last, the only interesting portion is shown below.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 new file mode 100644
 index 0000000..5d27866
 --- /dev/null
@@ -259,7 +259,7 @@ Listing all commits in our repository is useful, being able to filter this outpu
 
 Suppose we want to view all the commits that we made in the last week, typing the following into the command line in our test repository yields the following result.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log -p --since="last week"
 commit a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -292,7 +292,7 @@ This type of filtering can be exceedingly useful to a developer.  Often when pro
 
 If the developer can further categorise the issue, such as, ``I know which file the change must have occurred in'', then the following example will demonstrate just how easy it is to filter the results even further.  Even in the simplified example repository that we have been using, running this command filters the output to a single file.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log -p --since="last week" -- 
 my_second_committed_file
 commit a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
@@ -353,14 +353,14 @@ In this example, the \texttt{1} may refer to the major version number, and will 
 
 Git implements tags in a very elegant way.  A tag is simply a label in Git that points to a single commit object.  The tag name can then be used in place of the SHA-1 to refer to a point in the repositories history.  Due to the simplicity of tags, it is also possible and very simple to tag a commit that occurred way into the past.  Let us take a look at a simple tag example.  We will make the current point in the repository \texttt{v1.0a}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git tag v1.0a
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
 
 On its own, this doesn't really tell us much, but running the following, shows us a little more information
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git rev-parse v1.0a
 a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
 john@satsuki:~/coderepo$ 
@@ -368,14 +368,14 @@ john@satsuki:~/coderepo$
 
 By running the \texttt{git rev-parse} with the tag name \texttt{v1.0a}, Git has returned us the SHA-1 hash of the commit we were referring to.  If we look back up at the earlier output, we can see that the most recent commit into the repository was indeed \textbf{a022d4d1edc69970b4e8b3fe1da3dccd943a55e4}.  To give us something to work with, let's tag the commit \textbf{163f06\ldots} with the tag name \texttt{v0.9}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git tag v0.9 163f06
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
 
 Now, we can do the following;
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff v0.9..v1.0a
 diff --git a/my_second_committed_file b/my_second_committed_file
 index 3ad4cc3..c9887f8 100644
@@ -459,7 +459,7 @@ Now that we have taken a quick look at our three methods, we must decide which o
 
 So now let us see how we can use \texttt{git checkout} to take one of our files back to the past.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git status
 # On branch master
 nothing to commit (working directory clean)
@@ -472,7 +472,7 @@ Changed this file completely
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git status
 # On branch master
 nothing to commit (working directory clean)
@@ -498,7 +498,7 @@ We then switch the file back to the latest version by using the \texttt{HEAD} re
 \subsection{Show me the money}
 The \texttt{git show} command will have largely the same effect, except it grabs us the data without having to change existing files in our working copy.  Let us view a quick example.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git show v0.9:my_second_committed_file
 Change1
 john@satsuki:~/coderepo$ git show v0.9:my_second_committed_file > 

--- a/chap3.tex
+++ b/chap3.tex
@@ -414,7 +414,7 @@ John gave Michael the raised eyebrow look.  It wasn't the first time Michael had
 
 ``Tell ya what Michael,'' he grinned, ``Since this isn't the first time you've come to me with this kind of predicament, why don't you go and find out how to use Git to get the file back.''  Michael sighed.  ``I have tagged the repo each time we created an archive, so tell me what I need to run to extract it.''
 
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``Man'', started Michael running over to John's desk forty five minutes later.  ``I never knew there were so many ways to skin a cat''
 
@@ -527,7 +527,7 @@ Michael paused, clearly considering each method in his head.  The noise from the
 
 ``You could have also branched,'' shouted Rob, who was a few steps ahead of him.
 
-\begin{center}* * *\end{center}
+\thoughtbreak
 
 ``So, what's the status then John?'' asked Markus.
 

--- a/chap4.tex
+++ b/chap4.tex
@@ -31,7 +31,7 @@ First, we should probably start off by answering that very question and describi
 
 This is best illustrated by a little demonstration, so we are going to take our testing repository and branch off to try out new, wonderful and wacky things.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ ls
 my_first_committed_file   my_third_committed_file
 my_second_committed_file  temp_file
@@ -46,7 +46,7 @@ From looking at the output, it would appear that our \texttt{git branch wacky} c
 
 Well yes we did.  However we have not yet switched to it.  To do this, we use our good friend \texttt{git checkout}.  This will change the working copy to reflect the most recent commit in that branch, and will reset our HEAD accordingly, so that it points to this latest commit
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout wacky
 Switched to branch 'wacky'
 john@satsuki:~/coderepo$ git branch
@@ -59,7 +59,7 @@ Now the \texttt{*} has moved to be in front of the word \texttt{wacky} and we ha
 
 We will start off by taking a deeper look at what is present in our branch.  Running a \texttt{git log} shows us the history of our branch.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log
 commit a022d4d1edc69970b4e8b3fe1da3dccd943a55e4
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -89,7 +89,7 @@ john@satsuki:~/coderepo$
 
 You may notice here that the log messages being displayed are identical to that which we had before in our \textbf{master} branch.  This is nothing to be worried about.  You may be wondering how these can be present if we are in a totally separate environment.  Well, though we have branched, the history that led us to this point is the same.  As we have not made any changes yet, we do not notice any divergence.  If we now make changes to the \emph{repository} we can take a look and see how this will affect things.  To start with, let us remove a few files from the working tree, commit these actions, then add a few more, stage them and commit the new files.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git rm my_first_committed_file
 rm 'my_first_committed_file'
 john@satsuki:~/coderepo$ git rm my_second_committed_file
@@ -112,7 +112,7 @@ john@satsuki:~/coderepo$
 
 So we have made two new commits to the repository under our new branch.  If we run a Linux \texttt{ls} command to see the files which are in the working tree, we can see that our working copy has indeed altered.  We will also use our \texttt{git log} tool to see what the latest commit is.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ ls
 my_third_committed_file  newfile1  newfile2  temp_file
 john@satsuki:~/coderepo$ git log -n1
@@ -126,7 +126,7 @@ john@satsuki:~/coderepo$
 
 Brilliant.  As you can see, we have used \texttt{git log} in a slightly different way to limit the number of commits.  This is what the \texttt{-n} parameter is used for.  However, what happens if we go back to the \textbf{master} branch again?  In theory we should have everything back the way we left it just before creating the branch.  Let's move back into our \textbf{master} branch and examine the state of play.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout master
 Switched to branch 'master'
 john@satsuki:~/coderepo$ ls
@@ -152,7 +152,7 @@ Comparing that to our previous \texttt{ls} command, we can see that this is exac
 So there are really two pointers in our repository at the moment, from a branch point of view.  One of them points to commit \textbf{a022d4d\ldots} and is called \textbf master.  The other is called \textbf{wacky} and points to \textbf{55fb69f
 \ldots}.  At this point you may be thinking that branches are pretty much the same thing as tags.  Well, they are except for one important fact.  We are going to use our \texttt{git branch} command, with a new parameter, to show us the difference.  Take a look at the output of the following operations.  We have pruned the output of the \texttt{git show} command for brevity.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout wacky 
 Switched to branch 'wacky'
 john@satsuki:~/coderepo$ git branch -v
@@ -168,7 +168,7 @@ commit 55fb69f4ad26fdb6b90ac6f43431be40779962dd
 
 So here we have added a tag in our current branch, \textbf{wacky}, and we can see that the commit ID for the tag \textbf{v2.0} points \textbf{55fb69f}.  We can also see that the branch \textbf{wacky} is currently pointing to the same commit ID, \textbf{55fb69f}.  Now let us add another file in, make a commit and see what happens after this.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ echo "New stuff" > another_file
 john@satsuki:~/coderepo$ git add another_file
 john@satsuki:~/coderepo$ git commit -m 'Added another file'
@@ -199,7 +199,7 @@ Of course we could do this the old fashioned way.  We could switch into our \tex
 
 Let us take a litle look at the command output of a simple merge, explain it a little, and then look at a diagrammatic representation.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git branch
   master
 * wacky
@@ -208,7 +208,7 @@ john@satsuki:~/coderepo$
 
 Firstly we check just to see what branch we are on.  Next we checkout the branch we want our development branch to be merged into.  In this case, we want to merge \textbf{wacky} into \textbf{master} and so we must first checkout the \textbf{master} branch.  Then we can merge in the changes from our \textbf{wacky} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout master
 Switched to branch 'master'
 john@satsuki:~/coderepo$ 
@@ -216,7 +216,7 @@ john@satsuki:~/coderepo$
 
 Now we can run the actual merge.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git merge wacky 
 Updating a022d4d..9710177
 Fast-forward
@@ -238,7 +238,7 @@ We can see that the first line after our command shows us which commit \textbf{m
 
 We are going to perform a quick check, to see that we are in fact on the master branch and that the latest log message is the one from the point we last left the \textbf{wacky} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log -n1
 commit 9710177657ae00665ca8f8027b17314346a5b1c4
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -289,7 +289,7 @@ It is one hundred percent true.  How many times have you been working on somethi
 
 For now let us see how we can take our working copy changes into a new branch to continue development of some wonderful new feature.  We are going to start by making some changes to our newfiles.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ echo "and some more changes" >> newfile1
 john@satsuki:~/coderepo$ echo "and a new feature" >> newfile2
 john@satsuki:~/coderepo$ 
@@ -297,7 +297,7 @@ john@satsuki:~/coderepo$
 
 Now we are going to make a new branch and switch into it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout -b wonderful
 M	newfile1
 M	newfile2
@@ -309,7 +309,7 @@ Did you see that?  We managed to create a new branch and move into it in one go.
 
 Now we can commit these changes.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git commit -a -m 'Fantastic new feature'
 [wonderful cfbecab] Fantastic new feature
  2 files changed, 2 insertions(+), 0 deletions(-)
@@ -354,7 +354,7 @@ This wouldn't work in all situations, but then there are other techniques descri
 
 We actually have two ways of clearing up this particular situation.  The first of these is to use \texttt{git revert} to undo the changes of each commit.  Whilst this will work, we have two problems, a) we do not know how to use the \texttt{git revert} tool yet, and b) we can actually handle this situation much more cleanly.  We are going to make a new branch, make a few commits and then look at a diagram of our recent work to see how we can work things out.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout master
 Already on 'master'
 john@satsuki:~/coderepo$ git branch zaney
@@ -395,7 +395,7 @@ We already discussed one method using \texttt{git revert}, which we are due to c
 
 So let us take a look at the command line output and see how we achieve this.  Hopefully you should be familiar with most of the commands.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout zaney
 Switched to branch 'zaney'
 john@satsuki:~/coderepo$ git merge master
@@ -413,7 +413,7 @@ Now we reach step 4 in our set of instructions.  The one function we do not know
 
 We are now going to perform the last step using an old friend called \texttt{git reset}.  You may be thinking that \texttt{git reset} is only used to reset files in the index, but in fact, \texttt{git reset} can actually perform many more tasks.  We are going to use it with the \texttt{--hard} option.  This option can be dangerous, as it will discard all modifications in the working tree, so use with caution.  If we had uncommitted changes in our repository at this point, we could not have used this option.  Let's use the command and see where we get.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git reset --hard 9710177
 HEAD is now at 9710177 Added another file
 john@satsuki:~/coderepo$ 
@@ -425,7 +425,7 @@ The \texttt{git reset} command does not only work for rewinding back in time.  I
 
 Finally we are going to introduce one more use of the \texttt{git log} command to show us how our repository looks in a semi-graphical way.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git log --graph --pretty=oneline --all 
 --abbrev-commit  --decorate
 * 7cc32db (zaney) Made another awesome change
@@ -452,7 +452,7 @@ Be aware that during this work we have changed the history of at least one of ou
 
 We have had some awesome fun working with branches, and hopefully you can see how utterly powerful Git is.  Sometimes though we can get ourselves into trouble and it is here that Git can also come to our rescue.  Let us learn how to delete a branch.  We are going to delete our \textbf{wacky} branch now as we have already merged it and no longer require it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git branch -d zaney 
 error: The branch 'zaney' is not fully merged.
 If you are sure you want to delete it, run 'git branch -D zaney'.
@@ -471,7 +471,7 @@ All is most definitely not lost.  Even though we have removed all references to 
 
 We already know the commit ID that the branch was pointing to.  Git has been very kind and told us it, just before it carried out the delete.  We are looking for commit \textbf{7cc32db}.  If we run the command below, we will create and recover our branch in one go.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git branch zaney 7cc32db
 john@satsuki:~/coderepo$ git branch -v
 * master    9710177 Added another file
@@ -483,7 +483,7 @@ john@satsuki:~/coderepo$
 
 Our branch has been restored and points to the same place as it did before we deleted it.  As each commit points to its parent, we now have the complete history of \textbf{zaney} restored and the branch can be used as normal.  To complete this action, let us delete the \textbf{wacky} branch as originally intended.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git branch -d wacky
 Deleted branch wacky (was 9710177).
 john@satsuki:~/coderepo$ git branch -v
@@ -520,7 +520,7 @@ Conflicts are bound to happen at some point.  Even the best project processes in
 
 First we are going to add a little change to one of our files.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ echo "Another update to this file" >> 
  my_third_committed_file 
 john@satsuki:~/coderepo$ git commit -a -m 'Updated third file'
@@ -531,7 +531,7 @@ john@satsuki:~/coderepo$
 
 Now let us merge in our \textbf{wonderful} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git merge wonderful
 Merge made by recursive.
  newfile1 |    1 +
@@ -550,7 +550,7 @@ So far, our merge has gone pretty well.  We have taken all of the changes that w
 
 Our repository tree looks a little strange now.  Notice that the most recent commit, \textbf{b119573}, has two parents.  Can this be true?  If we run our \texttt{git show} command against that commit ID, we see something new.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git show b119573
 commit b119573f4508514c55e1c4e3bebec0ab3667d071
 Merge: 4ac9201 cfbecab
@@ -570,7 +570,7 @@ So now the history of this latest commit actually relies on two previous commits
 
 Let us now remove that third file before merging in the \textbf{zaney} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git rm my_third_committed_file
 rm 'my_third_committed_file'
 john@satsuki:~/coderepo$ git commit -a -m 'Removed third file'
@@ -582,7 +582,7 @@ john@satsuki:~/coderepo$
 
 So now we are ready to merge in the \textbf{zaney} branch.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git merge zaney
 Auto-merging newfile1
 CONFLICT (content): Merge conflict in newfile1
@@ -596,14 +596,14 @@ Oh dear!  That probably did not go as well as we had hoped.  We have two conflic
 
 In this case we have a conflict because the files have changed in both sides of the merge, since they diverged.  Rephrasing this slightly: Since the point when we created the branch \textbf{zaney}, at commit \textbf{55fb69}, both the \textbf{master} branch and the \textbf{zaney} branch have both modified the same files in the same places.  Right now, our merge is paused.  For now, let us abort the merge so that we can take a closer look at what happened.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git reset --merge
 john@satsuki:~/coderepo$ 
 \end{Verbatim}
 
 So let us compare the changes between our latest common ancestor and our branch tips.  We will first look at the difference between the ancestor and our \textbf{master} branch, but limit it to the files with conflicts.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff 55fb69 master -- newfile*
 diff --git a/newfile1 b/newfile1
 index 24e7dfa..ef20984 100644
@@ -624,7 +624,7 @@ john@satsuki:~/coderepo$
 
 Now we will do the same between the common ancestor and the tip of \textbf{zaney}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git diff 55fb69 zaney -- newfile*
 diff --git a/newfile1 b/newfile1
 index 24e7dfa..d94dacc 100644
@@ -645,7 +645,7 @@ john@satsuki:~/coderepo$
 
 So hopefully you can see that we have tried to change the second line in both files.  This is where the conflict is arising from.  Let us try to run the merge again and this time we will resolve the conflicts manually.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git merge zaney
 Auto-merging newfile1
 CONFLICT (content): Merge conflict in newfile1
@@ -673,21 +673,21 @@ We have displayed the contents of \texttt{newfile1} and \texttt{newfile2} during
 
 We are going to edit \texttt{newfile1} to look like this:
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 A new file
 and some more awesome changes
 \end{Verbatim}
 
 We will also edit \texttt{newfile2} to look like this:
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 Another new file
 and a new awesome feature
 \end{Verbatim}
 
 Now we have resolved the conflicts and set the files straight, we can add the files and commit the result.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git add newfile*
 john@satsuki:~/coderepo$ git commit -a -m 'Merged in zaney'
 [master d50ffb2] Merged in zaney

--- a/chap5.tex
+++ b/chap5.tex
@@ -12,22 +12,12 @@ It would seem that the team have coped with the initial usage of Git and that th
 
 It is because of these very factors that you should probably consider employing a parallel implementation.  This is exactly what John decided to do with Tamagoyaki Inc's implementation of Git.  Whilst a parallel implementation does take duplicate effort in some areas, it also allows the team to return to their original system, should insurmountable obstacles present themselves.  However, a parallel implementation should never be an excuse not to eventually shift over to the new system, unless serious issues are discovered.
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Terminology}{Parallel Implementation}
 Parallel implementation means keeping your old system running, whilst bringing up a new one.  It incurs extra effort in many areas, such as system administration, backups and system usage, but it allows people to evaluate a product in a real life situation.  Usually people will have completed all of their preliminary testing before moving onto Parallel implementation.  It would be assumed that you were fairly certain that your were going to move forward with a final implementation, before taking the time of setting up and training people on the new system.
 \newline
 \newline
 It does however allow people to continue with the day jobs, without the risk of issues with the new system completely blocking them from working.  This is often a critical factor when implementing a new system.  If the system is successful, over time, the users will migrate away from the old system and start using the new system exclusively.  Care should also be taken that whilst in the midst of parallel implementation, both systems remain up to date at all times, this is often the trickiest part.  In Tamagoyaki Inc's case, because they were just using tarballs of their code base, it is easy for them to tar up a folder, as well as commit it to the repository.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Parallel Implementation};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Terminology}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 \begin{trenches}
 ``I'm sorry John, but I just can't do this anymore!''  Eugene was leaning over the partition wall, the keys that hung around his neck clattering loudly as he swayed.  ``You hard core devs may be happy with all that command line junk, but I'm a GUI kinda guy.  It doesn't come as easily for me as if does for you.''

--- a/chap5.tex
+++ b/chap5.tex
@@ -30,7 +30,7 @@ Eugene was livid, ``You're such a damn elitist Klaus.  I'm so glad I don't have 
 
 Klaus shrugged.
 
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``Listen Eugene, I think I have a way to help you out.  There is a GUI component to Git that you can use.''  John was trying his best, but five minutes of grovelling to Eugene, hadn't exactly paid off.
 

--- a/chap6.tex
+++ b/chap6.tex
@@ -41,7 +41,7 @@ That may seem like a lot of work.  OK, the benefit is a fairly awesome one, but 
 
 The \texttt{git stash} command is used for exactly these situations.  Let us make a quick example of how to use it in our test repository.  To begin with we are going to make a few changes to the \textbf{master} branch, before we are interrupted.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git checkout master
 Already on 'master'
 john@satsuki:~/coderepo$ echo "Number strings rule 1234" >> 
@@ -51,7 +51,7 @@ john@satsuki:~/coderepo$
 
 So now we are interrupted and we have to make some important, and urgent changes to our \textbf{master} branch.  The example that follows is one way that we could use the \texttt{git stash} command to help us out.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git stash
 Saved working directory and index state WIP on master: d50ffb2 Merged 
  in zaney
@@ -65,7 +65,7 @@ john@satsuki:~/coderepo$
 
 So using the \texttt{git stash} command, we have squirrelled all of our developmental changes away into a \emph{stash}.  Now we have completed the mega important change that just could not wait, we are ready to pull our changes back from the stash.  First let us see just what the stash contains.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git stash list
 stash@{0}: WIP on master: d50ffb2 Merged in zaney
 john@satsuki:~/coderepo$ git stash show stash@{0}
@@ -84,7 +84,7 @@ john@satsuki:~/coderepo$
 
 As you can see, the \texttt{-p} option to the \texttt{git stash show} command shows us exactly what is contained in the stash.  We can apply this stash by running the following;
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git stash apply stash@{0}
 # On branch master
 # Changed but not updated:
@@ -112,7 +112,7 @@ Our stash has been applied to the current branch, in our case \textbf{master}, a
 
 Interestingly though, our stash still exists.  If we had used the \texttt{git stash pop} command instead of the \texttt{git stash apply}, our stash would have been removed.  Of course we can have multiple stashes in our repository.  For completeness sake, let us learn how to manually remove a stash, and take a look at how our repository looks with our semi-graphical \texttt{git log}
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ git stash drop stash@{0}
 Dropped stash@{0} (193f27172fc0df278105b981815c7718204030d8)
 john@satsuki:~/coderepo$ git log --graph --pretty=oneline --all 
@@ -174,20 +174,20 @@ So cloning is an excellent way of taking a copy of our repository, in essence it
 
 The git clone tool doesn't just copy the data though, it does several other things.  Let us create a clone of our test repository to another local location.  In this case, we are going to clone the repository into a folder called \texttt{coderepo-cl}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~$ git clone coderepo coderepo-cl
 Initialized empty Git repository in /home/john/coderepo-cl/.git/
 john@satsuki:~$ 
 \end{Verbatim}
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~$ cd coderepo-cl
 john@satsuki:~/coderepo-cl$ ls 
 another_file  newfile1  newfile2
 john@satsuki:~/coderepo-cl$
 \end{Verbatim}
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git status
 # On branch master
 nothing to commit (working directory clean)
@@ -228,7 +228,7 @@ Rob began walking over to John, ``Yeh, try running git branch with the r paramet
 
 You may be thinking that we now have a detached copy of the other branches in our repository.  That's not exactly accurate.  Let us run the command that Rob suggested and see what is happening.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git branch
 * master
 john@satsuki:~/coderepo-cl$ git branch -r
@@ -243,7 +243,7 @@ Whilst we have all the objects in our repository, we do not yet have our branche
 
 Let us take a look at what we can do with these remote tracking branches.  Notice in the output above, we have the word \texttt{origin} in front of the branch names.  When we clone a repository, Git automatically sets up what is called a \emph{remote}.  We can view this by using the \texttt{git remote} tool.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git remote
 origin
 john@satsuki:~/coderepo-cl$ git remote -v
@@ -256,7 +256,7 @@ As you can see from the output above, the \textbf{origin} remote definition poin
 
 We are going to spend a little while now learning about remote branches and how they differ to local branches.  Let us spend a few minutes trying some of our normal operations against a remote branch.  The first operation we are going to try is a diff.  We are going to run a diff between our current \textbf{master} branch and the \textbf{wonderful} branch as it stands in the original repository, so we should be diffing between \texttt{master} and \texttt{origin/wonderful}.  For brevity, we are also going to limit the changes shown to those which affect \texttt{newfile1} only, by appending \texttt{ -- <filename>} to the command.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git diff master origin/wonderful -- 
  newfile1
 diff --git a/newfile1 b/newfile1
@@ -275,7 +275,7 @@ So we can see that our diff command completed successfully.  Note that this comm
 
 Let us run another command now and learn a little more about what the remote reference \textbf{origin} really means.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git remote show origin
 * remote origin
   Fetch URL: /home/john/coderepo
@@ -294,7 +294,7 @@ john@satsuki:~/coderepo-cl$
 
 Though this command introduces some terms that we are not yet familiar with yet, like push, pull and fetch, we can see that the \textbf{origin} remote has been set up to \emph{track} three branches called, \textbf{master}, \textbf{wonderful} and \textbf{zaney}.  So although these branches are not yet usable in the way a local branch would be, it is comforting to know that Git does know about them.  Let us continue playing with the remote branch and run a \texttt{git log} command against it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git log origin/master -- newfile1
 commit 9cb2af2a00fd2253060e6bf8cc6c377b3d55ecea
 Author: John Haskins <john.haskins@tamagoyakiinc.koala>
@@ -316,7 +316,7 @@ Date:   Fri Apr 1 07:42:04 2011 +0100
 
 Again, this requires no connection to the \textbf{origin} repository at all and works as expected.  Let us try something really funky now, let us try checking out a remote branch so that we can view the filesystem.  We are now going to try checking out the remote branch called \textbf{wonderful}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git checkout origin/wonderful
 Note: checking out 'origin/wonderful'.
 
@@ -339,7 +339,7 @@ Interesting.  This is not what we are used to seeing.  When we have checked out 
 
 Running the \texttt{git branch} command below confirms our suspicions.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git branch -v
 * (no branch) cfbecab Fantastic new feature
   master      37950f8 Continued Development
@@ -348,7 +348,7 @@ john@satsuki:~/coderepo-cl$
 
 So we really need to figure out how to make these branches exist locally so that we can commit to them and retain those commits.  To do this we use the \texttt{git branch} tool again, but we use it in a slightly different manner.  
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git checkout -b wonderful origin/wonderful 
 Branch wonderful set up to track remote branch wonderful from origin.
 Switched to a new branch 'wonderful'
@@ -364,7 +364,7 @@ With a remote tracking branch, we can pull in the changes from the remote reposi
 
 By running the \texttt{git remote} tool again, we can see which branches are set up locally to track their remote counterparts in \textbf{origin}.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git remote show origin
 * remote origin
   Fetch URL: /home/john/coderepo
@@ -385,7 +385,7 @@ john@satsuki:~/coderepo-cl$
 
 What we are going to do now is make some changes to our original repository and see how we can view those changes and indeed pull them into our current local working repository, or clone.  Note that in the following code examples we have switched back to working on our original repository, in the \texttt{coderepo} folder.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ cd ../coderepo
 john@satsuki:~/coderepo$ git branch
 * master
@@ -414,7 +414,7 @@ john@satsuki:~/coderepo$
 
 As you can see, we have switched back to working on our old \textbf{orgin} and have bought \textbf{wonderful} to be in line with master and have added a new file and committed the changes.  Now let us go back to our clone and see if we can see those changes.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo$ cd ../coderepo-cl/
 john@satsuki:~/coderepo-cl$ git diff wonderful origin/
 origin/HEAD        origin/master      origin/wonderful   origin/zaney 
@@ -430,7 +430,7 @@ The first method is by running a \texttt{git pull} command.  If you remember the
 
 We mentioned that there were two methods to perform the procedure.  Whilst the first one is to use \texttt{git pull}, the second one actually achieves an almost identical result, but by running two commands instead of one.  In point of fact, these two commands are executed by the \texttt{git pull} command.  Running them as two separate commands allows us to understand a little more about what is happening.  Let us run the command and then explain what we have done.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git fetch origin
 remote: Counting objects: 4, done.
 remote: Compressing objects: 100% (2/2), done.
@@ -498,7 +498,7 @@ Now this causes a problem when we are trying to see what has been modified in th
 
 At first glance this may seem like a rather odd thing to want.  Why would we want a repository that doesn't have a working tree?  The simple answer is that a \emph{bare} repository allows us to be able to push changes into it.  Let us recreate the error message that Rob was talking about.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ echo "This is another update to newfile3" 
  >> newfile3
 john@satsuki:~/coderepo-cl$ git commit -a -m 'Added more to newfile3'
@@ -508,7 +508,7 @@ john@satsuki:~/coderepo-cl$ git commit -a -m 'Added more to newfile3'
 
 We have made a modification to the \textbf{wonderful} branch.  So let us now try to push that back to the \textbf{origin} remote repository with the \texttt{git push} command.
  
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git push
 Counting objects: 5, done.
 Compressing objects: 100% (3/3), done.
@@ -540,7 +540,7 @@ john@satsuki:~/coderepo-cl$
 
 Bingo!  There is the error we were looking for.  In order to get round this, we are going to create another clone of the repository in \texttt{coderepo}.  This time however, we are going to pass an option to it when we create it.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ cd ..
 john@satsuki:~$ git clone coderepo coderepo-bk --bare
 Initialized empty Git repository in /home/john/coderepo-bk/
@@ -557,7 +557,7 @@ As you can see, creating the clone with the \texttt{--bare} option has had a def
 
 We are getting closer to making our push.  We have created a \emph{bare} repository, which we should now be able to push to.  The problem is, we have not yet defined our new repository as a remote location in the \texttt{coderepo-cl} repository.  This is something we will do now and to do this, we will use our \texttt{git remote} tool once more, this time employing the \texttt{add} parameter.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git remote add backup 
  /home/john/coderepo-bk
 john@satsuki:~/coderepo-cl$ git remote show backup
@@ -577,7 +577,7 @@ john@satsuki:~/coderepo-cl$
 
 We have created a remote called backup.  As you can see, some interrogation of the remote repository has taken place.  It is already aware of the branches present in our remote location.  Let us do a \texttt{git fetch} to update the local references.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git fetch backup
 From /home/john/coderepo-bk
  * [new branch]      master     -> backup/master
@@ -600,7 +600,7 @@ john@satsuki:~/coderepo-cl$
 
 Now we can see that all of the remote references for our \textbf{backup} remote have been updated.  If we run a diff against our local \textbf{wonderful} branch and the remote branch \textbf{backup/wonderful}, we can see the differences.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git diff wonderful backup/wonderful 
 diff --git a/newfile3 b/newfile3
 index 7268b97..638113c 100644
@@ -614,7 +614,7 @@ john@satsuki:~/coderepo-cl$ git branch -v
 
 There we go!  Those are the changes we just committed to the local repository.  The last thing we need to do is to initiate a \texttt{git push}.  We are going to have to define which remote we wish to push to now for two reasons.  The first is that now we have two remotes, and so Git would not know if we meant \textbf{origin} or \textbf{backup}.  The second reason is that by default, the \textbf{wonderful} branch is set up to push to the \textbf{origin} remote.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git push backup
 Counting objects: 5, done.
 Compressing objects: 100% (3/3), done.
@@ -628,7 +628,7 @@ john@satsuki:~/coderepo-cl$
 
 There we go, we have now managed to push our changes to a remote location.  In this case, we have pushed an update from the \textbf{wonderful} branch to the \textbf{backup/wonderful branch}.  If we wanted to, we could have pushed our repository to a new branch name, or indeed any of the existing branch names.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@satsuki:~/coderepo-cl$ git push backup wonderful:newbranch
 Total 0 (delta 0), reused 0 (delta 0)
 To /home/john/coderepo-bk

--- a/chap6.tex
+++ b/chap6.tex
@@ -159,7 +159,7 @@ Markus nodded and smiled.  It seemed that John had gotten away with it for now a
 
 ``Team,'' began Markus, ``we need a definitive way of backing up the new Git repository, and I'd like it done before the end of the day.''  He pointed at a document on the table.  ``This project document has been approved by Wayne, and in there it states we will have a defined backup strategy.  Please don't let me down.''
 
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``Rob you really got to be careful about things like that,'' Klaus said to one of the younger members of the team.  ``You really showed John up in there.''  
 
@@ -214,7 +214,7 @@ Rob's reply was quick and certain, ``They have!  Run a git branch on your clone 
 
 Rob smiled the smug smile of a man who is pleased he was right.
 
-\begin{center} * * * \end{center}
+\thoughtbreak
 
 ``Rob?'' asked John tentatively, aware of his previous state of anguish.
 

--- a/chap6.tex
+++ b/chap6.tex
@@ -489,22 +489,12 @@ Klaus smiled and his head appeared over the cubicle.  ``Come over here genius an
 
 Bare?  Non-bare?  At first glance, this may seem confusing.  It isn't exactly an intuitive word to describe a repository but what Klaus mentioned was absolutely true.  In Git, if you want to push changes back to a repository, instead of pulling them, the repository that you push to should be what is called a \emph{bare} repository.  What this means is that the repository has no working copy.
 
-\begin{figure}[hbt]
-\tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
-\tikzstyle{fancytitle} =[fill=black, text=white]
-\begin{tikzpicture}
-\node [mybox] (box){%
-    \begin{minipage}{.9\textwidth}
+\begin{callout}{Note}{Pushing to a non-bare repository}
 As mentioned, pushing to a non-bare repository is not a good idea.  When you push to a repository, you update the objects in the objects database.  This will affect commits, blobs and trees.  We should make a distinction here.  We are really only worried about pushing to a branch which is currently checked out.  Pushing to a non-bare repository will mean that the index will get changed, as it should reflect what the branch looks like at HEAD.  
 \newline
 \newline
 Now this causes a problem when we are trying to see what has been modified in the working directory when compared to the HEAD.  As our working copy will contain older versions of the files than are in the index, it will appear as if many more changes have occured and we risk undoing those changes.  For these reasons, it is much simpler just to push only to bare repositories.
-    \end{minipage}
-};
-\node[fancytitle, right=16pt] at (box.north west) {Pushing to a non-bare repository};
-\node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{Note}};
-\end{tikzpicture}
-\end{figure}
+\end{callout}
 
 At first glance this may seem like a rather odd thing to want.  Why would we want a repository that doesn't have a working tree?  The simple answer is that a \emph{bare} repository allows us to be able to push changes into it.  Let us recreate the error message that Rob was talking about.
 

--- a/chap7.tex
+++ b/chap7.tex
@@ -12,7 +12,7 @@ Now we have a complete copy of our repository in another location.  At the momen
 
 If we assume that for a moment that our user \emph{john} has now moved to another machine and now wishes to clone a repository that he had on his original machine to this new one.  The commands are identical to that which we used before.  We are going to assume that \emph{john} already has SSH access to the machine.  In this way, we can issue the commands as follows.
 
-\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}] 
+\begin{Verbatim}
 john@akira:~$ git clone ssh://john@satsuki/home/john/coderepo coderepo-ne
 Initialized empty Git repository in /home/john/coderepo-ne/.git/
 john@akira's password: 

--- a/commands.tex
+++ b/commands.tex
@@ -1,7 +1,0 @@
-% commands.tex - various things we want to use throughout the document, conveniently defined here
-
-% give us a begin{trenches}
-\newenvironment{trenches}{\begin{quote}\begin{rmfamily}\textbf{In the trenches\ldots\\\\}}{\end{rmfamily}\end{quote}}
-
-% attempted the same for codeoutput but didn't work
-\newenvironment{codeoutput}{\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]}{\end{Verbatim}}

--- a/gitt.cls
+++ b/gitt.cls
@@ -90,5 +90,9 @@
   \end{figure}%
 }
 
+% Indicates thought breaks
+\newcommand{\thoughtbreak}{%
+  \par\begin{center}*\quad*\quad*\end{center}\par
+}
 
 

--- a/gitt.cls
+++ b/gitt.cls
@@ -1,0 +1,64 @@
+%
+% Book design for Git in the Trenches
+%
+
+\NeedsTeXFormat{LaTeX2e}[1994/06/01]
+
+\ProvidesClass{gitt}[2011/05/15 v1.0.0 GITT book design]
+
+
+
+\LoadClass[a5paper,openright,12pt]{memoir}
+
+% set paper size
+\setlrmarginsandblock{2.16cm}{1.91cm}{*}
+\setulmarginsandblock{1.91cm}{1.91cm}{*}
+\checkandfixthelayout
+
+% Import packages
+\RequirePackage{graphicx}
+\RequirePackage{color,fancyvrb,relsize}
+\RequirePackage[final]{microtype}
+\RequirePackage{tikz}
+
+% Import a new font and use the sans-serif version by default
+\RequirePackage{lmodern}
+\renewcommand{\familydefault}{\sfdefault}
+
+% Put chapters and sections in the toc, only number the chapter
+\setcounter{tocdepth}{3}
+\setcounter{secnumdepth}{0}
+
+% Make chapter names disappear
+\renewcommand{\chaptername}{}
+\renewcommand{\thechapter}{}
+\renewcommand{\tablename}{}
+\renewcommand{\thetable}{}
+
+% Make the pdf have clickable links
+\RequirePackage[
+  bookmarks,
+  bookmarksopen,
+  bookmarksnumbered=false,
+  colorlinks,
+  pdfpagemode=None,
+  urlcolor=black,
+  citecolor=black,
+  linkcolor=black,
+  pagecolor=black,
+  plainpages=false,
+  pdfpagelabels,
+  pdftitle={Git In the Trenches},
+  pdfauthor={Peter Savage}]{hyperref}
+
+\AtBeginDocument{
+  \hyphenpenalty=1000
+  \tolerance=1000
+}
+
+% give us a begin{trenches}
+\newenvironment{trenches}{\begin{quote}\begin{rmfamily}\textbf{In the trenches\ldots\\\\}}{\end{rmfamily}\end{quote}}
+
+% attempted the same for codeoutput but didn't work
+\newenvironment{codeoutput}{\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]}{\end{Verbatim}}
+

--- a/gitt.cls
+++ b/gitt.cls
@@ -63,8 +63,8 @@
 % give us a begin{trenches}
 \newenvironment{trenches}{\begin{quote}\begin{rmfamily}\textbf{In the trenches\ldots\\\\}}{\end{rmfamily}\end{quote}}
 
-% attempted the same for codeoutput but didn't work
-\newenvironment{codeoutput}{\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]}{\end{Verbatim}}
+% Set the default formatting options for the Verbatim environment
+\fvset{frame=leftline,framerule=1mm,fontsize=\relsize{-3}}
 
 % Callout boxes
 \newsavebox{\callout@contents}

--- a/gitt.cls
+++ b/gitt.cls
@@ -6,6 +6,10 @@
 
 \ProvidesClass{gitt}[2011/05/15 v1.0.0 GITT book design]
 
+\DeclareOption*{%
+  \PassOptionsToClass{\CurrentOption}{memoir}%
+}
+\ProcessOptions*\relax
 
 
 \LoadClass[a5paper,openright,12pt]{memoir}
@@ -61,4 +65,30 @@
 
 % attempted the same for codeoutput but didn't work
 \newenvironment{codeoutput}{\begin{Verbatim}[frame=leftline,framerule=1mm,fontsize=\relsize{-3}]}{\end{Verbatim}}
+
+% Callout boxes
+\newsavebox{\callout@contents}
+\newcommand{\callout@type}{}
+\newcommand{\callout@title}{}
+\newenvironment{callout}[2]{%
+  \xdef\callout@type{#1}% typeset in a box along the left
+  \xdef\callout@title{#2}% typeset in a box along the top
+  \begin{lrbox}{\callout@contents}%
+    \begin{minipage}{.9\textwidth}%
+}{%
+    \end{minipage}%
+  \end{lrbox}%
+  \begin{figure}[hbt]%
+    \tikzstyle{mybox} = [draw=black, fill=gray!20, very thick, rectangle, rounded corners, inner sep=15pt, inner ysep=20pt]
+    \tikzstyle{fancytitle} = [fill=black, text=white]
+    \hskip-10pt% allows the type block to hang into the left margin
+    \begin{tikzpicture}%
+      \node[mybox] (box) {\usebox{\callout@contents}};
+      \node[fancytitle, right=16pt] at (box.north west) {\callout@title};
+      \node[fancytitle, rounded corners] at (box.west) {\rotatebox{90}{\callout@type}};
+    \end{tikzpicture}%
+  \end{figure}%
+}
+
+
 

--- a/gitt.tex
+++ b/gitt.tex
@@ -1,58 +1,11 @@
-% intro.tex - Introduction
-\documentclass[a5paper,openright,12pt]{memoir}
-
-% set paper size
-\setlrmarginsandblock{2.16cm}{1.91cm}{*}
-\setulmarginsandblock{1.91cm}{1.91cm}{*}
-\checkandfixthelayout
-
-% Import packages
-\usepackage{graphicx}
-\usepackage{color,fancyvrb,relsize}
-\usepackage[final]{microtype}
-\usepackage{tikz}
-
-% Import a new font and use the sans-serif version by default
-\usepackage{lmodern}
-\renewcommand{\familydefault}{\sfdefault}
-
-% Put chapters and sections in the toc, only number the chapter
-\setcounter{tocdepth}{3}
-\setcounter{secnumdepth}{0}
-
-% Make chapter names disappear
-\renewcommand{\chaptername}{}
-\renewcommand{\thechapter}{}
-\renewcommand{\tablename}{}
-\renewcommand{\thetable}{}
-
-% Make the pdf have clickable links
-\usepackage[
-  bookmarks,
-  bookmarksopen,
-  bookmarksnumbered=false,
-  colorlinks,
-  pdfpagemode=None,
-  urlcolor=black,
-  citecolor=black,
-  linkcolor=black,
-  pagecolor=black,
-  plainpages=false,
-  pdfpagelabels,
-  pdftitle={Git In the Trenches},
-  pdfauthor={Peter Savage}]{hyperref}
+\documentclass{gitt}
 
 % Title/author/date
 \title{Git In the Trenches}
 \author{Peter Savage}
-\input{commands}
 \date{February 2011}
 
 \begin{document}
-
-% Latex preferences
-\hyphenpenalty=1000
-\tolerance=1000
 
 % Preamble stuff
 \maketitle
@@ -60,21 +13,21 @@
 \tableofcontents
 
 % Include all the individual chapters
-\input{intro}
-\input{chap1}
-\input{afterhours1}
-\input{chap2}
-\input{afterhours2}
-\input{chap3}
-\input{afterhours3}
-\input{chap4}
-\input{afterhours4}
-\input{chap5}
-\input{afterhours5}
-\input{chap6}
-\input{afterhours6}
-\input{chap7}
-\input{afterhours7}
-\input{ack}
+\include{intro}
+\include{chap1}
+\include{afterhours1}
+\include{chap2}
+\include{afterhours2}
+\include{chap3}
+\include{afterhours3}
+\include{chap4}
+\include{afterhours4}
+\include{chap5}
+\include{afterhours5}
+\include{chap6}
+\include{afterhours6}
+\include{chap7}
+\include{afterhours7}
+\include{ack}
 
 \end{document}


### PR DESCRIPTION
I moved the code from the preamble and commands.tex to a new document class.  This simplifies the gitt.tex file quite a bit.

I changed \input to \include in gitt.tex as \include will automatically insert the page breaks.

I tweaked the Makefile, also.  You need to run pdflatex multiple times to finalize the table of contents.  When you run it just once, it generates the table of contents, but doesn't include it in the PDF until a later pass.  I added some more files to the clean target (the files that LaTeX (re)generates each time it's run).

I also added a .gitignore file that ignores the files generated by LaTeX.

I created a callout environment to replace the verbose figure/tikzpicture environments you were using for the gray callout boxes.  The syntax for the callout environment is:

```
\begin{callout}{<type>}{<title>}
  The contents of the callout box.
\end{callout}
```

where `<type>` is printed along the left border of the callout box and `<title>` is printed along the top border.

I replaced all of the \begin{center} \* \* \* \end{center} bits with a new macro named \thoughtbreak.  We can make this macro a bit fancier in the future.

I set a default format for the Verbatim environments and removed the optional arguments from them in the .tex files.  That should make maintenance and new code easier to write.
