### PR TITLE
Only print the chapter name in the verso running head

### DIFF
--- a/chap7.tex
+++ b/chap7.tex
@@ -53,8 +53,11 @@ Tamagoyaki are about to embark on their decision making process regarding which 
 
 This is just a short list of the questions that you will need to consider when implementing a full on Git environment.  The beauty of the Git system though, is that it is flexible and very difficult to box yourself into a corner, where a decision made early on prohibits a different approach later on.
 
-The Git
-
 \section{Day 2 - ``Now let's work together''}
 \subsection{Pure collaboration}
 
+We are now armed with a much clearer idea of how Git works and indeed we are now in a position to actually implement the developmental model that the team of Tamagoyaki need in order to collaborate on their projects.  It should be noted that although we have reached the point of being able to work together on a project, this is not where out discussions about Git will end.  We still have a large number of topics to cover and these will be visited as required during the subsequent implementation of Git at Tamagoyaki.
+
+\begin{trenches}
+
+\end{trenches}

--- a/gitt.cls
+++ b/gitt.cls
@@ -39,6 +39,9 @@
 \renewcommand{\tablename}{}
 \renewcommand{\thetable}{}
 
+% Print just the chapter name without 'Chapter #.' in the running heads
+\renewcommand\chaptermark[1]{\markboth{\memUChead{#1}}{}}%
+
 % Make the pdf have clickable links
 \RequirePackage[
   bookmarks,


### PR DESCRIPTION
This removes the stray period from the running head on the left-hand side page.
