### PR TITLE
Use new title page (for pdf version)

### DIFF
--- a/gitt.cls
+++ b/gitt.cls
@@ -24,6 +24,7 @@
 \RequirePackage{color,fancyvrb,relsize}
 \RequirePackage[final]{microtype}
 \RequirePackage{tikz}
+\RequirePackage{pdfpages}
 
 % Import a new font and use the sans-serif version by default
 \RequirePackage{lmodern}

--- a/gitt.tex
+++ b/gitt.tex
@@ -8,8 +8,12 @@
 \begin{document}
 
 % Preamble stuff
-\maketitle
+\includepdf{images/source/fcover.pdf}
 \cleardoublepage
+
+%\maketitle
+%\cleardoublepage
+
 \tableofcontents
 
 % Include all the individual chapters


### PR DESCRIPTION
- use package pdfpages for importing pdfs
- make fcover.pdf the default title and comment out the old version

Pull request for issue #16
