### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
-all: pdf html
+all: pdf cleantmp
+quick: quickpdf cleantmp
+clean: cleantmp cleanpdf
 
 pdf:
-	pdflatex gitt.tex
+	pdflatex gitt
 	makeindex gitt
-	pdflatex gitt.tex
-	pdflatex gitt.tex
+	pdflatex gitt
+	pdflatex gitt
 
-#html:
-#	latex2html -html 4.0,unicode,latin1,utf8 -split 2 gitt.tex
+quickpdf:
+	pdflatex gitt
 
-clean:
-	rm gitt -Rf
-	rm -f *.aux *.log *.out *.toc *.idx *.ind *.ilg gitt.pdf
+cleantmp:
+	rm -f *.aux *.log *.out *.toc *.idx *.ind *.ilg
+
+cleanpdf:
+	rm -f gitt.pdf


### PR DESCRIPTION
- Make default target clean up the intermediary files after compile
- Add 'quick' to make a quick build without caring about references breaking
- Add 'cleantmp' to remove the intermediary files
- Add 'cleanpdf' to remove the PDF
- Remove non-working html target from default
