### PR TITLE
Fixed Typo (missing "\" for textbf)

### DIFF
--- a/chap7.tex
+++ b/chap7.tex
@@ -354,7 +354,7 @@ Martha giggled.
 \end{trenches}
 
 \index{rebasing!interactive}Looking at our example commits, it would appear that we have made the same mistake as Simon.
-Our commits, \textbf{c0e2f5b} and textbf{8c6a66b} have got the same commit message.
+Our commits, \textbf{c0e2f5b} and \textbf{8c6a66b} have got the same commit message.
 Not very helpful at all.
 Let us see how \texttt{git rebase} can help us out here.
 

--- a/chap7.tex
+++ b/chap7.tex
@@ -215,7 +215,7 @@ The best way to get round this is to use the rebase tool.
 
 \index{replaying commits}As mentioned, the rebase tool can find a common ancestor between two branches, pick up the new commits on your new branch, update the branch underneath and the replay your commits on top.
 Figure 2, shows a fairly standard commit tree.
-We have made commits \textbf{A} and \textbf{B}, and then we branch off and create \textbf{C} and textbf{D}.
+We have made commits \textbf{A} and \textbf{B}, and then we branch off and create \textbf{C} and \textbf{D}.
 It could well be that the \textbf{master} branch containing \textbf{A} and \textbf{B} actually came from an external source, and we are looking to do some development in our own branch locally.
 
 \begin{figure}[hbt]


### PR DESCRIPTION
just two missing "\" typos

Awesome book!
