### PR TITLE
Remove references to /home/pete/GITT in the SVG image sources

### DIFF
--- a/images/source/bcover-new.svg
+++ b/images/source/bcover-new.svg
@@ -1467,7 +1467,7 @@
       <image
          width="158.99471"
          height="111.48261"
-         xlink:href="file:///home/pete/GITT/images/raster/w5-d8.png"
+         xlink:href="file://../raster/w5-d8.png"
          id="image23823"
          x="461.36859"
          y="645.89813" />

--- a/images/source/combinedcover.svg
+++ b/images/source/combinedcover.svg
@@ -1393,7 +1393,7 @@
       <image
          width="158.99471"
          height="111.48261"
-         xlink:href="file:///home/pete/GITT/images/raster/w5-d8.png"
+         xlink:href="file://../raster/w5-d8.png"
          id="image23823"
          x="461.36859"
          y="645.89813" />

--- a/images/source/w5-d1.svg
+++ b/images/source/w5-d1.svg
@@ -56,10 +56,10 @@
        y="425.21933"
        x="254.5"
        id="image3079"
-       xlink:href="file:///home/pete/GITT/images/raster/w5-d1.png"
+       xlink:href="file://../raster/w5-d1.png"
        height="500"
        width="811"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <path
@@ -74,7 +74,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -84,7 +84,7 @@
        y="611.59296"
        id="text3084"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -105,7 +105,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -115,7 +115,7 @@
        y="798.51605"
        id="text3084-5"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -136,7 +136,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -146,7 +146,7 @@
        y="610.82373"
        id="text3084-5-7"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -167,7 +167,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -177,7 +177,7 @@
        y="820.0545"
        id="text3084-5-9"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"

--- a/images/source/w5-d8.svg
+++ b/images/source/w5-d8.svg
@@ -56,7 +56,7 @@
        y="344.13141"
        x="152.61539"
        id="image3212"
-       xlink:href="file:///home/pete/GITT/images/raster/w5-d8.png"
+       xlink:href="file://../raster/w5-d8.png"
        height="718"
        width="1024" />
     <path
@@ -71,7 +71,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
        transform="translate(-21.538462,-75.384615)" />
@@ -82,7 +82,7 @@
        y="536.20831"
        id="text3084"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -103,7 +103,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -113,7 +113,7 @@
        y="535.43915"
        id="text3084-5"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -134,7 +134,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -144,7 +144,7 @@
        y="535.43909"
        id="text3084-5-7"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -165,7 +165,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -175,7 +175,7 @@
        y="695.43915"
        id="text3084-5-9"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -196,7 +196,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -206,7 +206,7 @@
        y="756.9776"
        id="text3084-5-9-3"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -227,7 +227,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -237,7 +237,7 @@
        y="896.97766"
        id="text3084-5-9-6"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"
@@ -258,7 +258,7 @@
        sodipodi:start="1.5707964"
        sodipodi:end="7.8539816"
        sodipodi:open="true"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90" />
     <text
@@ -268,7 +268,7 @@
        y="898.51605"
        id="text3084-5-9-4"
        sodipodi:linespacing="125%"
-       inkscape:export-filename="/home/pete/GITT/images/f-w5-d1.png"
+       inkscape:export-filename="../f-w5-d1.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"><tspan
          sodipodi:role="line"


### PR DESCRIPTION
In the SVG images, there were some absolute paths - both as the export paths and in referenced images. I've done a simple `sed -i  "s_/home/pete/GITT/images/_../_g" images/source/*` which seems to have worked.
