### PR TITLE
fix the image Read Now link

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -135,7 +135,7 @@
                 </tr>
                 <tr>
                   <td>&nbsp;</td>
-                  <td><a href="read.html"><img src="images/read_now.png" alt="Read Now" width="129" height="29" border="0" class="read_now"></a></td>
+                  <td><a href="intro.html"><img src="images/read_now.png" alt="Read Now" width="129" height="29" border="0" class="read_now"></a></td>
                 </tr>
               </table></td>
             </tr>


### PR DESCRIPTION
The image read now link goes to read.html which doesn't exist. I've made it point to the same place as the text read now link.
