### PR TITLE
Typo 'sqush' -> 'squash'

### DIFF
--- a/chap7.tex
+++ b/chap7.tex
@@ -442,10 +442,10 @@ So, if we change the ID of a preceeding commit, all subsequent ones have to chan
 \end{callout}
 
 Let us try this rebase again.
-This time we will use the sqush option to merge the two similar commits into one.
+This time we will use the squash option to merge the two similar commits into one.
 We will run the same command as before; \texttt{git rebase -i HEAD\textasciitilde3}.
 This time we will use the \texttt{s} prefix to the line to choose \emph{squashing} as our method.
-We could have used the word \texttt{sqush} instead of \texttt{s}, but for the laziness in all of us, we will opt for the single letter versions for now.
+We could have used the word \texttt{squash} instead of \texttt{s}, but for the laziness in all of us, we will opt for the single letter versions for now.
 
 \begin{code}
 pick c0e2f5b Updated another file


### PR DESCRIPTION
Signed-off-by: Stefan Naewe stefan.naewe@googlemail.com
