### PR TITLE
Fix description of config file

### DIFF
--- a/afterhours2.tex
+++ b/afterhours2.tex
@@ -36,7 +36,7 @@ john@satsuki:~/coderepo/.git$
 
 \textbf{config} - This is the main configuration file for Git.
 It is the first place git looks for upon invocation.
-If this file is not present, Git will inspect \texttt{\textasciitilde{}/.gitconfig}.
+If a config item is not found in this file, or this file is not present at all, Git will inspect \texttt{\textasciitilde{}/.gitconfig}.
 After this, Git will go to \texttt{/etc/gitconfig}.
 The file holds information about the remotes, tracking branches, push configurations and many more items.
 


### PR DESCRIPTION
The description made it look like ~/.gitconfig wasn't read at all
when .git/config was available.
