### PR TITLE
Switched arrows in DAG to point backwards in time

### DIFF
--- a/images/source/w4-d1.svg
+++ b/images/source/w4-d1.svg
@@ -13,7 +13,7 @@
    height="473.54944"
    id="svg3093"
    version="1.1"
-   inkscape:version="0.48.1 r9760"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="w4-d1.svg">
   <defs
      id="defs3095">
@@ -277,16 +277,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.2018265"
-     inkscape:cx="204.58389"
-     inkscape:cy="226.39889"
+     inkscape:zoom="3.3992787"
+     inkscape:cx="180.65897"
+     inkscape:cy="205.46955"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1366"
-     inkscape:window-height="693"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      units="cm"
      fit-margin-top="1"
@@ -340,7 +340,7 @@
          y="142.36221">commit</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
-       d="m 85,162.36218 0,20"
+       d="m 85,183.1902 0,-20"
        id="path4917"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -461,7 +461,7 @@
          y="282.36218">Finished adding initial files</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
-       d="m 85,232.36218 0,20"
+       d="m 85,253.1902 0,-20"
        id="path4917-3"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -508,7 +508,7 @@
          y="352.36224">Messed with a few files</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
-       d="m 85,302.36224 0,20"
+       d="m 85,323.19026 0,-20"
        id="path4917-3-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -607,13 +607,13 @@
          y="492.36224">Added two new files</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
-       d="m 155,442.36224 0,20"
+       d="m 155,463.19026 0,-20"
        id="path4917-3-0-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
        style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
-       d="m 85,372.36218 c 15,15 50,5 70,20"
+       d="m 155.57298,392.67308 c -15,-15 -50,-5 -69.999996,-20"
        id="path4917-3-0-3"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />


### PR DESCRIPTION
The image used in w4-d1 is pointing forward in time, not possible from a git point of view. I flipped them to point backwards. Only did this to the source svg image. Not sure how you create the actual image used in the book.
